### PR TITLE
Initial BNE Implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ notes.synctex.gz
 notes.out
 notes.log
 notes.aux
+q.log


### PR DESCRIPTION
Baseline BNE implementation. There is a possibility I got something wrong here, but I basically just copied over everything I saw from the existing BEQ implementation and made the required modifications. I don't THINK there is anything special about the BNE implementation that'd require me to modify anything anywhere that doesn't already have BEQ code for it, but if I'm wrong and there is then this implementation is missing whatever that component is. (though again, I'm pretty sure this is a rather simple conversion)

One important note is that I noticed the initial definitions seem to be a bit inconsistent. In lazyvim some of the spaces have greyed out ">" between them and some are just normal spaces. I think the difference is tab-spacing vs normal-space-spacing and it might not matter, but it's worth noting the descrepancy. In either case, just to be safe I copied the BEQ definition line exactly and just modified it, so if the invisible ">" symbols do have some semantic meaning my BNE definition should still be valid since it's defined in the same way as BEQ was.

(FYI I'm kinda doing some dirty git work here to make the PR's a bit more organized. Like I said in my email my break was a lot more hectic than anticipated so I didn't get to finish up anything fully and only partially worked on everything, but to make the PR's a bit cleaner I'm picking out the changes for each instruction and everything, finishing them up, then treating them as one set of changes even though technically they were made alongside the changes for everything else. It's a bodge but it shouldn't be an issue I don't think)